### PR TITLE
Remove references to Python 3.12 typing feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "relationalize"
-version = "0.1.8"
+version = "0.1.9"
 authors = [
   { name="Henry Jones", email="henry.jones@tulip.co" },
 ]

--- a/relationalize/sql_dialects.py
+++ b/relationalize/sql_dialects.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Generic, Literal, NewType, TypeVar, override
+from typing import Generic, Literal, NewType, TypeVar
 
 from relationalize.types import SupportedColumnType
 
@@ -65,7 +65,6 @@ CREATE TABLE IF NOT EXISTS "{schema}"."{table_name}" (
     """.strip()
 
     @staticmethod
-    @override
     def generate_ddl_column(column_name: str, column_type: PostgresColumn):
         cleaned_column_name = column_name.replace('"', '""')
         return DDLColumn(f'"{cleaned_column_name}" {column_type}')


### PR DESCRIPTION
the `@override` feature was only added in python 3.12. my linter tricked me into thinking it was a current day feature that i needed to add for best practices purposes.